### PR TITLE
Shoot projectiles in the right direction

### DIFF
--- a/BinTree/Assets/Animations/GirlFaceLeft.anim
+++ b/BinTree/Assets/Animations/GirlFaceLeft.anim
@@ -20,7 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0.8, y: 0, z: 0}
+        value: {x: -0.8, y: 0, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -91,7 +91,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.8
+        value: -0.8
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/BinTree/Assets/Animations/GirlFaceRight.anim
+++ b/BinTree/Assets/Animations/GirlFaceRight.anim
@@ -20,7 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: -0.8, y: 0, z: 0}
+        value: {x: 0.8, y: 0, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -91,7 +91,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -0.8
+        value: 0.8
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/BinTree/Assets/Animations/GirlMoveLeft.anim
+++ b/BinTree/Assets/Animations/GirlMoveLeft.anim
@@ -20,7 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0.8, y: 0, z: 0}
+        value: {x: -0.8, y: 0, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -192,7 +192,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0.8
+        value: -0.8
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/BinTree/Assets/Animations/GirlMoveRight.anim
+++ b/BinTree/Assets/Animations/GirlMoveRight.anim
@@ -20,7 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: -0.8, y: 0, z: 0}
+        value: {x: 0.8, y: 0, z: 0}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -173,7 +173,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -0.8
+        value: 0.8
         inSlope: 0
         outSlope: 0
         tangentMode: 136

--- a/BinTree/Assets/Scripts/StarController.cs
+++ b/BinTree/Assets/Scripts/StarController.cs
@@ -16,7 +16,7 @@ public class StarController : MonoBehaviour
         starRigidBody = GetComponent<Rigidbody2D>();
         player = FindObjectOfType<PlayerController>();
 
-        if(player.lastMove.x > 0f)
+        if(player.lastMove.x < 0f)
         {
             moveSpeed = -moveSpeed;
         }


### PR DESCRIPTION
Changed the shooting orientation depending on how the player is faced. For example if the player is moving left or standing left-faced it will be able to shoot projectiles in his left side. In order to do this I changed the player animations by modifing the firepoint's position(if the player is oriented to the left the firepoint will be on his left side). Analog, for the right side of the player. For the up and down sides I left the shooting the same, meaning the player will shoot in the right.